### PR TITLE
Various tweaks on UI

### DIFF
--- a/both/i18n/en-us.i18n.yml
+++ b/both/i18n/en-us.i18n.yml
@@ -60,7 +60,7 @@ chainStatus:
     activeValidators: 'Active Validators'
     outOfValidators: 'out of {$totalValidators} validators'
     onlineVotingPower: 'Online Voting Power'
-    fromTotalStakes: '{$percent} from {$totalStakes} {$denom}s'
+    fromTotalStakes: '{$percent} from {$totalStakes} {$denomPlural}'
 analytics:
     blockTimeHistory: 'Block Time History'
     averageBlockTime: 'Average Block Time'

--- a/both/utils/coins.js
+++ b/both/utils/coins.js
@@ -17,6 +17,7 @@ autoformat = (value) => {
 
 export default class Coin {
 	static StakingDenom = Meteor.settings.public.stakingDenom;
+	static StakingDenomPlural = Meteor.settings.public.stakingDenomPlural || (Coin.StakingDenom + 's');
 	static MintingDenom = Meteor.settings.public.mintingDenom;
 	static StakingFraction = Number(Meteor.settings.public.stakingFraction);
 	static MinStake = 1 / Number(Meteor.settings.public.stakingFraction);

--- a/both/utils/coins.js
+++ b/both/utils/coins.js
@@ -16,17 +16,17 @@ autoformat = (value) => {
 }
 
 export default class Coin {
-	static StakingDenom = Meteor.settings.public.stakingDenom.toLowerCase();
-	static MintingDenom = Meteor.settings.public.mintingDenom.toLowerCase();
+	static StakingDenom = Meteor.settings.public.stakingDenom;
+	static MintingDenom = Meteor.settings.public.mintingDenom;
 	static StakingFraction = Number(Meteor.settings.public.stakingFraction);
 	static MinStake = 1 / Number(Meteor.settings.public.stakingFraction);
 
 	constructor(amount, denom=null) {
 		if (typeof amount === 'object')
 			({amount, denom} = amount)
-		if (!denom || denom.toLowerCase() === Coin.MintingDenom) {
+		if (!denom || denom.toLowerCase() === Coin.MintingDenom.toLowerCase()) {
 			this._amount = Number(amount);
-		} else if (denom.toLowerCase() === Coin.StakingDenom) {
+		} else if (denom.toLowerCase() === Coin.StakingDenom.toLowerCase()) {
 			this._amount = Number(amount) * Coin.StakingFraction;
 		}
 		else {
@@ -48,7 +48,7 @@ export default class Coin {
 		if (this.amount < minStake) {
 			return `${numbro(this.amount).format('0,0')} ${Coin.MintingDenom}`;
 		} else {
-			return `${precision?numbro(this.stakingAmount).format('0,0.' + '0'.repeat(precision)):autoformat(this.stakingAmount)} ${Coin.StakingDenom.toUpperCase()}`
+			return `${precision?numbro(this.stakingAmount).format('0,0.' + '0'.repeat(precision)):autoformat(this.stakingAmount)} ${Coin.StakingDenom}`
 		}
 	}
 
@@ -65,6 +65,6 @@ export default class Coin {
 		if (formatter) {
 			amount = numbro(amount).format(formatter)
 		}
-		return `${amount} ${Coin.StakingDenom.toUpperCase()}`;
+		return `${amount} ${Coin.StakingDenom}`;
 	}
 }

--- a/default_settings.json
+++ b/default_settings.json
@@ -15,6 +15,7 @@
         "stakingDenom": "ATOM",
         "mintingDenom": "uatom",
         "stakingFraction": 1000000,
+        "powerReduction": null,
         "gasPrice": 0.02,
         "coingeckoId": "cosmos"
     },

--- a/default_settings.json
+++ b/default_settings.json
@@ -13,6 +13,7 @@
         "bech32PrefixConsAddr": "cosmosvalcons",
         "bech32PrefixConsPub": "cosmosvalconspub",
         "stakingDenom": "ATOM",
+        "stakingDenomPlural": null,
         "mintingDenom": "uatom",
         "stakingFraction": 1000000,
         "powerReduction": null,

--- a/imports/ui/accounts/Delegations.jsx
+++ b/imports/ui/accounts/Delegations.jsx
@@ -22,7 +22,7 @@ export default class AccountDelegations extends Component{
                     <Row className="header text-nowrap d-none d-lg-flex">
                         <Col xs={6} md={4}><i className="fas fa-at"></i> <span><T>accounts.validators</T></span></Col>
                         <Col xs={3} md={4}><i className="fas fa-piggy-bank"></i> <span><T>accounts.shares</T></span></Col>
-                        <Col xs={3} md={4}><i className="fas fa-wallet"></i> <span><T>{Coin.StakingDenom}s</T></span></Col>
+                        <Col xs={3} md={4}><i className="fas fa-wallet"></i> <span><T>{Coin.StakingDenomPlural}</T></span></Col>
                     </Row>
                     {this.props.delegations.sort((b, a) => (a.balance - b.balance)).map((d, i) => {
                         return <Row key={i} className="delegation-info">

--- a/imports/ui/home/ChainStatus.jsx
+++ b/imports/ui/home/ChainStatus.jsx
@@ -4,6 +4,7 @@ import { Row, Col, Card, CardText,
 import numbro from 'numbro';
 import i18n from 'meteor/universe:i18n';
 import TimeStamp from '../components/TimeStamp.jsx';
+import Coin from '/both/utils/coins.js';
 
 const T = i18n.createComponent();
 
@@ -199,7 +200,7 @@ export default class ChainStatus extends React.Component {
                                     </DropdownMenu>
                                 </UncontrolledDropdown>
                                 <CardTitle><T>chainStatus.onlineVotingPower</T> ({this.state.votingPowerText})</CardTitle>
-                                <CardText><span className="display-4 value text-primary">{this.state.votingPower}</span><T percent={numbro(this.state.bondedTokens/this.state.totalSupply).format("0.00%")} totalStakes={numbro(this.state.totalSupply/Meteor.settings.public.stakingFraction).format("0.00a")} denom={Meteor.settings.public.stakingDenom}>chainStatus.fromTotalStakes</T></CardText>
+                                <CardText><span className="display-4 value text-primary">{this.state.votingPower}</span><T percent={numbro(this.state.bondedTokens/this.state.totalSupply).format("0.00%")} totalStakes={numbro(this.state.totalSupply/Coin.StakingFraction).format("0.00a")} denom={Coin.StakingDenom} denomPlural={Coin.StakingDenomPlural}>chainStatus.fromTotalStakes</T></CardText>
                             </Card>
                         </Col>
                     </Row>

--- a/imports/ui/ledger/LedgerActions.jsx
+++ b/imports/ui/ledger/LedgerActions.jsx
@@ -789,7 +789,7 @@ class TransferButton extends LedgerButton {
         if (!this.state.currentUser) return null;
         let maxAmount = this.state.currentUser.availableCoin;
         return <TabPane tabId="2">
-            <h3>Transfer {Coin.StakingDenom.toUpperCase()}</h3>
+            <h3>Transfer {Coin.StakingDenom}</h3>
             <InputGroup>
                 <Input name="transferTarget" onChange={this.handleInputChange}
                     placeholder="Send to" type="text"

--- a/imports/ui/proposals/Proposal.jsx
+++ b/imports/ui/proposals/Proposal.jsx
@@ -67,7 +67,8 @@ export default class Proposal extends Component{
             });
 
             let now = moment();
-            let totalVotingPower = this.props.chain.activeVotingPower * Meteor.settings.public.stakingFraction;
+            const powerReduction = Meteor.settings.public.powerReduction || Meteor.settings.public.stakingFraction;
+            let totalVotingPower = this.props.chain.activeVotingPower * powerReduction;
             if (this.props.proposal.voting_start_time != '0001-01-01T00:00:00Z'){
                 if (now.diff(moment(this.props.proposal.voting_start_time)) > 0){
                     let endVotingTime = moment(this.props.proposal.voting_end_time);
@@ -270,7 +271,8 @@ export default class Proposal extends Component{
             if (this.props.proposalExist && this.state.proposal != ''){
                 // console.log(this.state.proposal);
                 const proposalId = Number(this.props.proposal.proposalId), maxProposalId = Number(this.props.proposalCount);
-                let totalVotingPower = this.props.chain.activeVotingPower * Meteor.settings.public.stakingFraction;
+                const powerReduction = Meteor.settings.public.powerReduction || Meteor.settings.public.stakingFraction;
+                let totalVotingPower = this.props.chain.activeVotingPower * powerReduction;
                 return <div>
                     <Helmet>
                         <title>{this.props.proposal.content.value.title} | The Big Dipper</title>


### PR DESCRIPTION
1. display tokens as set in `stakingDenom` instead of upper case or lower case in various places
2. add `pricePrecision` setting (default is 2), so tokens with lower price can be displayed instead of showing `$0.00`
3. add `powerReduction` setting (default is `null`, which fallbacks to `stakingFraction`) to fix the voting power calculation in proposals (#215 )
4. add `stakingDenomPlural` setting (default is `null`, which fallbacks to `${stakingDenom}s`) to allow setting the text of the plural form of the token. This also fixes the additional newline in account delegation list table header.