### PR TITLE
Big Dipper Translated to Polish

### DIFF
--- a/both/i18n/pl-PL.i18n.yml
+++ b/both/i18n/pl-PL.i18n.yml
@@ -24,7 +24,7 @@ common:
     retry: 'Spróbuj ponownie'
     rewards: 'Nagrody'
 navbar:
-    siteName: 'The Big Dipper'
+    siteName: 'Wielki Wóz'
     version: 'beta'
     validators: 'Walidatorzy'
     blocks: 'Bloki'


### PR DESCRIPTION
Big Dipper Translated to Polish as 'Wielki Wóz'